### PR TITLE
feat: ai comment

### DIFF
--- a/.github/workflows/ai-comment-bot.yml
+++ b/.github/workflows/ai-comment-bot.yml
@@ -1,0 +1,88 @@
+name: AI Comment Bot
+
+on:
+  issue_comment:
+    types: [created]
+
+jobs:
+  trigger-paper-helper:
+    # Only run on comments containing @paper-helper
+    if: contains(github.event.comment.body, '@paper-helper')
+    runs-on: ubuntu-latest
+    permissions:
+      issues: read
+
+    steps:
+      - name: Generate GitHub App token
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Owen-Liuyuxuan
+          repositories: paper-helper-server
+
+      - name: Extract page URL and dispatch to server
+        uses: actions/github-script@v7
+        env:
+          SERVER_TOKEN: ${{ steps.generate-token.outputs.token }}
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const commentBody = context.payload.comment.body;
+            const commenter = context.payload.comment.user.login;
+            
+            console.log(`Processing comment from ${commenter} on issue #${issueNumber}`);
+            
+            // Get the issue body to extract the page URL
+            const { data: issue } = await github.rest.issues.get({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber
+            });
+            
+            // Extract URL from issue body (utterances format)
+            let pageUrl = '';
+            const urlMatch = issue.body?.match(/https?:\/\/[^\s\]]+/);
+            if (urlMatch) {
+              pageUrl = urlMatch[0].replace(/[)\]>]+$/, '');
+            }
+            
+            if (!pageUrl) {
+              console.log('Could not find URL in issue body, using base URL as fallback');
+              pageUrl = `https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/`;
+            }
+            
+            console.log(`Extracted page URL: ${pageUrl}`);
+            
+            // Dispatch to server repository using repository_dispatch for better automation support
+            const serverToken = process.env.SERVER_TOKEN;
+            const octokit = github.getOctokit(serverToken);
+            
+            try {
+              await octokit.rest.repos.createDispatchEvent({
+                owner: 'Owen-Liuyuxuan',
+                repo: 'paper-helper-server',
+                event_type: 'ai_comment_request',
+                client_payload: {
+                  client_repo: `${context.repo.owner}/${context.repo.repo}`,
+                  issue_number: issueNumber.toString(),
+                  comment_body: commentBody,
+                  commenter: commenter,
+                  page_url: pageUrl
+                }
+              });
+              
+              console.log('Successfully dispatched repository_dispatch to paper-helper-server');
+            } catch (error) {
+              console.error('Failed to dispatch:', error.message);
+              
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} Sorry, Paper Helper encountered an error triggering the analysis.\n\nError: ${error.message}`
+              });
+              
+              throw error;
+            }

--- a/.github/workflows/ai-comment-bot.yml
+++ b/.github/workflows/ai-comment-bot.yml
@@ -15,7 +15,7 @@ jobs:
     timeout-minutes: 5
     
     permissions:
-      issues: read
+      issues: write
       contents: read
 
     steps:

--- a/.github/workflows/ai-comment-bot.yml
+++ b/.github/workflows/ai-comment-bot.yml
@@ -4,48 +4,71 @@ on:
   issue_comment:
     types: [created]
 
+permissions:
+  contents: read
+
 jobs:
   trigger-paper-helper:
     # Only run on comments containing @paper-helper
     if: contains(github.event.comment.body, '@paper-helper')
     runs-on: ubuntu-latest
+    timeout-minutes: 5
+    
     permissions:
       issues: read
+      contents: read
 
     steps:
       - name: Check if commenter is a bot
         id: check-bot
+        timeout-minutes: 1
         run: |
           COMMENTER="${{ github.event.comment.user.login }}"
-          if [[ "$COMMENTER" == *"[bot]"* || "$COMMENTER" == *"bot"* ]]; then
+          echo "Commenter: $COMMENTER"
+          
+          # Check for bot patterns (more comprehensive)
+          if [[ "$COMMENTER" == *"[bot]" ]] || [[ "$COMMENTER" == *"-bot" ]] || [[ "$COMMENTER" == "github-actions"* ]]; then
             echo "Commenter is a bot ($COMMENTER). Skipping."
             echo "is_bot=true" >> $GITHUB_OUTPUT
           else
             echo "is_bot=false" >> $GITHUB_OUTPUT
           fi
 
-      - name: Generate GitHub App token
+      - name: Validate comment format
         if: steps.check-bot.outputs.is_bot == 'false'
-        id: generate-token
-        uses: actions/create-github-app-token@v1
-        with:
-          app-id: ${{ secrets.APP_ID }}
-          private-key: ${{ secrets.APP_PRIVATE_KEY }}
-          owner: Owen-Liuyuxuan
-          repositories: paper-helper-server
+        id: validate-comment
+        timeout-minutes: 1
+        run: |
+          COMMENT_BODY='${{ github.event.comment.body }}'
+          
+          # Check comment is not empty
+          if [ -z "$COMMENT_BODY" ]; then
+            echo "Empty comment body"
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          # Check comment length (max 10000 chars)
+          LENGTH=${#COMMENT_BODY}
+          if [ $LENGTH -gt 10000 ]; then
+            echo "Comment too long: $LENGTH characters"
+            echo "valid=false" >> $GITHUB_OUTPUT
+            exit 0
+          fi
+          
+          echo "valid=true" >> $GITHUB_OUTPUT
 
-      - name: Extract page URL and dispatch to server
-        if: steps.check-bot.outputs.is_bot == 'false'
+      - name: Extract and validate page URL
+        if: steps.check-bot.outputs.is_bot == 'false' && steps.validate-comment.outputs.valid == 'true'
+        id: extract-url
         uses: actions/github-script@v7
-        env:
-          SERVER_TOKEN: ${{ steps.generate-token.outputs.token }}
+        timeout-minutes: 1
         with:
           script: |
             const issueNumber = context.payload.issue.number;
-            const commentBody = context.payload.comment.body;
-            const commenter = context.payload.comment.user.login;
             
-            console.log(`Processing comment from ${commenter} on issue #${issueNumber}`);
+            console.log('=== URL Extraction ===');
+            console.log('Issue number:', issueNumber);
             
             // Get the issue body to extract the page URL
             const { data: issue } = await github.rest.issues.get({
@@ -61,14 +84,122 @@ jobs:
               pageUrl = urlMatch[0].replace(/[)\]>]+$/, '');
             }
             
+            // Validate extracted URL
             if (!pageUrl) {
-              console.log('Could not find URL in issue body, using base URL as fallback');
-              pageUrl = `https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/`;
+              console.log('Could not find URL in issue body, using base URL');
+              pageUrl = 'https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/';
+            } else {
+              // Validate URL format
+              try {
+                const url = new URL(pageUrl);
+                if (url.protocol !== 'https:') {
+                  console.log('Non-HTTPS URL found, using base URL');
+                  pageUrl = 'https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/';
+                }
+              } catch (e) {
+                console.log('Invalid URL format, using base URL');
+                pageUrl = 'https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/';
+              }
             }
             
-            console.log(`Extracted page URL: ${pageUrl}`);
+            // Ensure URL is within expected domain
+            const allowedDomain = 'owen-liuyuxuan.github.io';
+            try {
+              const url = new URL(pageUrl);
+              if (!url.hostname.includes(allowedDomain)) {
+                console.log('URL not in allowed domain, using base URL');
+                pageUrl = 'https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/';
+              }
+            } catch (e) {
+              pageUrl = 'https://owen-liuyuxuan.github.io/papers_reading_sharing.github.io/';
+            }
             
-            // Dispatch to server repository using repository_dispatch for better automation support
+            console.log('Extracted page URL:', pageUrl);
+            core.setOutput('page_url', pageUrl);
+
+      - name: Generate GitHub App token
+        if: steps.check-bot.outputs.is_bot == 'false' && steps.validate-comment.outputs.valid == 'true'
+        id: generate-token
+        uses: actions/create-github-app-token@v1
+        timeout-minutes: 1
+        with:
+          app-id: ${{ secrets.APP_ID }}
+          private-key: ${{ secrets.APP_PRIVATE_KEY }}
+          owner: Owen-Liuyuxuan
+          repositories: paper-helper-server
+
+      - name: Generate HMAC signature and dispatch
+        if: steps.check-bot.outputs.is_bot == 'false' && steps.validate-comment.outputs.valid == 'true'
+        id: dispatch-request
+        uses: actions/github-script@v7
+        timeout-minutes: 2
+        env:
+          SERVER_TOKEN: ${{ steps.generate-token.outputs.token }}
+          DISPATCH_SECRET: ${{ secrets.DISPATCH_SECRET }}
+          PAGE_URL: ${{ steps.extract-url.outputs.page_url }}
+        with:
+          script: |
+            const crypto = require('crypto');
+            
+            const issueNumber = context.payload.issue.number;
+            const commentBody = context.payload.comment.body;
+            const commenter = context.payload.comment.user.login;
+            const pageUrl = process.env.PAGE_URL;
+            
+            console.log('=== Dispatch Preparation ===');
+            console.log('Commenter:', commenter);
+            console.log('Issue:', issueNumber);
+            console.log('Page URL:', pageUrl);
+            
+            // Validate secret is configured
+            const secret = process.env.DISPATCH_SECRET;
+            if (!secret) {
+              console.error('DISPATCH_SECRET not configured');
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} Configuration error. Please contact the administrator.`
+              });
+              throw new Error('DISPATCH_SECRET not configured');
+            }
+            
+            // Create base payload with timestamp
+            const timestamp = Date.now();
+            const payload = {
+              client_repo: `${context.repo.owner}/${context.repo.repo}`,
+              issue_number: issueNumber.toString(),
+              comment_body: commentBody.substring(0, 10000), // Limit length
+              commenter: commenter,
+              page_url: pageUrl,
+              timestamp: timestamp
+            };
+            
+            // Generate HMAC-SHA256 signature
+            // Canonical payload must match server-side validation (exact field order)
+            const canonicalPayload = JSON.stringify({
+              client_repo: payload.client_repo,
+              issue_number: payload.issue_number,
+              comment_body: payload.comment_body,
+              commenter: payload.commenter,
+              page_url: payload.page_url,
+              timestamp: payload.timestamp
+            });
+            
+            const hmac = crypto.createHmac('sha256', secret);
+            hmac.update(canonicalPayload);
+            const signature = hmac.digest('hex');
+            
+            // Create signed payload
+            const signedPayload = {
+              ...payload,
+              signature: signature
+            };
+            
+            console.log('Signature generated:', signedPayload.signature.substring(0, 16) + '...');
+            console.log('Timestamp:', signedPayload.timestamp);
+            
+            // Dispatch to server repository
             const serverToken = process.env.SERVER_TOKEN;
             const octokit = github.getOctokit(serverToken);
             
@@ -77,25 +208,56 @@ jobs:
                 owner: 'Owen-Liuyuxuan',
                 repo: 'paper-helper-server',
                 event_type: 'ai_comment_request',
-                client_payload: {
-                  client_repo: `${context.repo.owner}/${context.repo.repo}`,
-                  issue_number: issueNumber.toString(),
-                  comment_body: commentBody,
-                  commenter: commenter,
-                  page_url: pageUrl
-                }
+                client_payload: signedPayload
               });
               
-              console.log('Successfully dispatched repository_dispatch to paper-helper-server');
+              console.log('✓ Successfully dispatched to paper-helper-server');
             } catch (error) {
-              console.error('Failed to dispatch:', error.message);
+              console.error('✗ Failed to dispatch:', error.message);
               
+              // Post error comment
               await github.rest.issues.createComment({
                 owner: context.repo.owner,
                 repo: context.repo.repo,
                 issue_number: issueNumber,
-                body: `@${commenter} Sorry, Paper Helper encountered an error triggering the analysis.\n\nError: ${error.message}`
+                body: `@${commenter} Sorry, Paper Helper encountered an error triggering the analysis. Please try again later.\n\n*Error: ${error.message}*`
               });
               
               throw error;
+            }
+
+      - name: Handle validation failure
+        if: steps.check-bot.outputs.is_bot == 'false' && steps.validate-comment.outputs.valid == 'false'
+        uses: actions/github-script@v7
+        timeout-minutes: 1
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            
+            await github.rest.issues.createComment({
+              owner: context.repo.owner,
+              repo: context.repo.repo,
+              issue_number: issueNumber,
+              body: `@${commenter} Your comment could not be processed. Please ensure it is properly formatted and not too long (max 10,000 characters).`
+            });
+
+      - name: Handle workflow failure
+        if: failure() && steps.check-bot.outputs.is_bot == 'false'
+        uses: actions/github-script@v7
+        timeout-minutes: 1
+        with:
+          script: |
+            const issueNumber = context.payload.issue.number;
+            const commenter = context.payload.comment.user.login;
+            
+            try {
+              await github.rest.issues.createComment({
+                owner: context.repo.owner,
+                repo: context.repo.repo,
+                issue_number: issueNumber,
+                body: `@${commenter} Paper Helper encountered an unexpected error. Please try again later or contact the administrator if the problem persists.`
+              });
+            } catch (error) {
+              console.error('Failed to post error message:', error.message);
             }

--- a/.github/workflows/ai-comment-bot.yml
+++ b/.github/workflows/ai-comment-bot.yml
@@ -13,7 +13,19 @@ jobs:
       issues: read
 
     steps:
+      - name: Check if commenter is a bot
+        id: check-bot
+        run: |
+          COMMENTER="${{ github.event.comment.user.login }}"
+          if [[ "$COMMENTER" == *"[bot]"* || "$COMMENTER" == *"bot"* ]]; then
+            echo "Commenter is a bot ($COMMENTER). Skipping."
+            echo "is_bot=true" >> $GITHUB_OUTPUT
+          else
+            echo "is_bot=false" >> $GITHUB_OUTPUT
+          fi
+
       - name: Generate GitHub App token
+        if: steps.check-bot.outputs.is_bot == 'false'
         id: generate-token
         uses: actions/create-github-app-token@v1
         with:
@@ -23,6 +35,7 @@ jobs:
           repositories: paper-helper-server
 
       - name: Extract page URL and dispatch to server
+        if: steps.check-bot.outputs.is_bot == 'false'
         uses: actions/github-script@v7
         env:
           SERVER_TOKEN: ${{ steps.generate-token.outputs.token }}

--- a/.gitignore
+++ b/.gitignore
@@ -2,3 +2,4 @@ site
 temp
 .vscode
 .venv
+.cursor

--- a/docs/index.md
+++ b/docs/index.md
@@ -41,6 +41,10 @@ Papers are now sorted in Several categories
 
 本博客站使用[utterances](https://github.com/utterance/utterances),对每一篇文章开启单独的评论区.
 
+## AI Q&A (since 2026.02)
+
+现在特定人员可以在评论区 @paper-helper触发AI回答，AI会阅读原论文以及网页上的信息并回答您的问题。由于Token的使用是花费token的金钱的，有需要使用者请用email/微信联系刘所
+
 <!-- <div id="tester" style="width:600px;height:250px;"></div>
 
 <script src="index.js">


### PR DESCRIPTION
1. Enable @/paper-helper for Gemini Query.
2. Ask me to enable your Github Account to use the function here.

<!-- CURSOR_SUMMARY -->
---

> [!NOTE]
> **Medium Risk**
> Adds a workflow that uses repo secrets and dispatches signed payloads to another repository; misconfiguration or overly-permissive domain/URL handling could leak data or enable unintended triggering.
> 
> **Overview**
> Introduces a new GitHub Actions workflow (`ai-comment-bot.yml`) that triggers on `issue_comment` creation containing `@paper-helper`, ignores bot commenters, validates comment size, extracts/sanitizes the related page URL, and then uses a GitHub App token plus an HMAC signature to `repository_dispatch` an `ai_comment_request` event to `Owen-Liuyuxuan/paper-helper-server` (with user-facing error comments on validation/workflow failures).
> 
> Updates docs (`docs/index.md`) to announce the new AI Q&A behavior and tweaks `.gitignore` to also ignore `.cursor`.
> 
> <sup>Written by [Cursor Bugbot](https://cursor.com/dashboard?tab=bugbot) for commit 64eb5c6cd08eedda28e13da5c770789fb29f9280. This will update automatically on new commits. Configure [here](https://cursor.com/dashboard?tab=bugbot).</sup>
<!-- /CURSOR_SUMMARY -->